### PR TITLE
Switch submodule URL to HTTPS protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libduckdb-sys/duckdb-sources"]
 	path = libduckdb-sys/duckdb-sources
-	url = git@github.com:duckdb/duckdb.git
+	url = https://github.com/duckdb/duckdb.git


### PR DESCRIPTION
This allows for environments where SSH traffic isn't allow, as well as not needing a specific git user configured. Since the duckdb project is public, we should use the "Smart HTTP" protocol:

https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols#_smart_http